### PR TITLE
chore: update kpk-devops clone URL for org rename (karpatkey → kpk)

### DIFF
--- a/release-prod/update_prod_if_release.sh
+++ b/release-prod/update_prod_if_release.sh
@@ -39,7 +39,7 @@ git config --global user.email "41898282+github-actions[bot]@users.noreply.githu
 TEMP_DIR=$(mktemp -d)
 cd "$TEMP_DIR"
 
-git clone "https://x-access-token:${KPK_DEVOPS_PAT}@github.com/karpatkey/kpk-devops.git"
+git clone "https://x-access-token:${KPK_DEVOPS_PAT}@github.com/kpk/kpk-devops.git"
 cd kpk-devops
 
 mkdir -p "$(dirname "$FILE_PATH")"

--- a/release-prod/update_prod_if_release.sh
+++ b/release-prod/update_prod_if_release.sh
@@ -39,8 +39,8 @@ git config --global user.email "41898282+github-actions[bot]@users.noreply.githu
 TEMP_DIR=$(mktemp -d)
 cd "$TEMP_DIR"
 
-git clone "https://x-access-token:${KPK_DEVOPS_PAT}@github.com/kpk/kpk-devops.git"
-cd kpk-devops
+git clone "https://x-access-token:${KPK_DEVOPS_PAT}@github.com/kpk/devops.git"
+cd devops
 
 mkdir -p "$(dirname "$FILE_PATH")"
 


### PR DESCRIPTION
## Summary

- Updates the hardcoded `github.com/karpatkey/kpk-devops.git` clone URL in `release-prod/update_prod_if_release.sh` to `github.com/kpk/kpk-devops.git`

## Context

Part of the org rename from `karpatkey` to `kpk`. This script clones `kpk-devops` to update ArgoCD image tags on release — the URL must be updated **before** the org rename takes effect to avoid a window where the script fails.

> **Note**: The GCP registry paths (`europe-docker.pkg.dev/karpatkey-data-warehouse/...`) in this file are intentionally not changed here — GCP project IDs are immutable and the registry migration is a separate workstream.

## Test plan
- [ ] Trigger a release in a repo that uses `release-prod` action and confirm the kpk-devops clone succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)