### PR TITLE
feat: add deployment readiness verification and modernize kubectl setup

### DIFF
--- a/preview-cleanup/action.yml
+++ b/preview-cleanup/action.yml
@@ -1,5 +1,5 @@
 name: "PR Cleanup Deployment"
-description: "Authenticate with GCP, get GKE credentials, install kubectl, and delete PR deployment resources."
+description: "Authenticate with GCP, get GKE credentials, and delete PR deployment resources."
 inputs:
   credentials_json:
     description: "GCP service account credentials JSON"
@@ -32,12 +32,8 @@ runs:
         cluster_name: ${{ inputs.cluster_name }}
         location: ${{ inputs.region }}
 
-    - name: Install kubectl
-      run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-      shell: bash
+    - name: Setup kubectl
+      uses: azure/setup-kubectl@v4
 
     - name: Extract Repository Name (lowercase)
       id: repo-name
@@ -50,9 +46,10 @@ runs:
 
     - name: Delete Kubernetes Resources
       run: |
-        # Use dynamic namespace: "pr-review-<repo_name>"
         NAMESPACE="pr-review-${{ steps.repo-name.outputs.repo_name }}"
-        kubectl delete deployment -n "$NAMESPACE" "${{ steps.repo-name.outputs.repo_name }}-${{ inputs.pr_number }}"
-        kubectl delete svc -n "$NAMESPACE" "${{ steps.repo-name.outputs.repo_name }}-${{ inputs.pr_number }}"
-        kubectl delete ing -n "$NAMESPACE" "${{ steps.repo-name.outputs.repo_name }}-${{ inputs.pr_number }}"
+        DEPLOY_NAME="${{ steps.repo-name.outputs.repo_name }}-${{ inputs.pr_number }}"
+        echo "Cleaning up ${DEPLOY_NAME} in namespace ${NAMESPACE}"
+        kubectl delete deployment -n "$NAMESPACE" "$DEPLOY_NAME" --ignore-not-found
+        kubectl delete svc -n "$NAMESPACE" "$DEPLOY_NAME" --ignore-not-found
+        kubectl delete ing -n "$NAMESPACE" "$DEPLOY_NAME" --ignore-not-found
       shell: bash

--- a/preview-deployment/action.yml
+++ b/preview-deployment/action.yml
@@ -1,5 +1,5 @@
 name: "GKE and PR Review Deployment"
-description: "Authenticate to GCP, get GKE credentials, install kubectl, and deploy a PR review environment."
+description: "Authenticate to GCP, get GKE credentials, and deploy a PR review environment with readiness verification."
 inputs:
   credentials_json:
     description: "GCP service account credentials JSON"
@@ -27,12 +27,25 @@ inputs:
     description: "Default Docker registry URL"
     required: false
     default: "europe-docker.pkg.dev/karpatkey-data-warehouse/karpatkey"
+  rollout_timeout:
+    description: "Timeout for deployment rollout (default 120s)"
+    required: false
+    default: "120s"
+
+outputs:
+  deployment_url:
+    description: "The URL of the deployed preview environment"
+    value: ${{ steps.set_url.outputs.deployment_url }}
+  deployment_status:
+    description: "Whether the deployment rolled out successfully (success/failure)"
+    value: ${{ steps.verify.outputs.status }}
+
 runs:
   using: "composite"
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Authenticate to GCP
       id: auth
       uses: google-github-actions/auth@v2
@@ -46,12 +59,8 @@ runs:
         cluster_name: ${{ inputs.cluster_name }}
         location: ${{ inputs.region }}
 
-    - name: Install kubectl
-      run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-      shell: bash
+    - name: Setup kubectl
+      uses: azure/setup-kubectl@v4
 
     - name: Extract Repository Name (lowercase)
       id: repo-name
@@ -69,42 +78,60 @@ runs:
         echo "docker_tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Set Deployment URL
+      id: set_url
+      run: |
+        echo "deployment_url=https://${{ inputs.pr_number }}-${{ steps.repo-name.outputs.repo_name }}.kpk.dev" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Prepare Deployment File
       run: |
-        # Copy the deployment template to a new file for modification
         cp "${{ inputs.templates_folder }}/deployment-template.yaml" deployment-temp.yaml
-        
-        # Replace placeholders with actual values:
+
         sed -i "s|{{DOCKER_TAG}}|${{ steps.set_docker_tag.outputs.docker_tag }}|g" deployment-temp.yaml
         sed -i "s|{{PR_SUBDOMAIN}}|${{ inputs.pr_number }}-${{ steps.repo-name.outputs.repo_name }}.kpk.dev|g" deployment-temp.yaml
         sed -i "s|{{PR_NUMBER}}|${{ inputs.pr_number }}|g" deployment-temp.yaml
         sed -i "s|{{REPO_NAME}}|${{ steps.repo-name.outputs.repo_name }}|g" deployment-temp.yaml
         sed -i "s|{{PORT}}|${{ inputs.port }}|g" deployment-temp.yaml
         sed -i "s|{{REGISTRY}}|${{ inputs.registry }}|g" deployment-temp.yaml
-        
-        # Optional: display the modified file for debugging
+
         cat deployment-temp.yaml
       shell: bash
-    
+
     - name: Prepare Ingress File
       run: |
         cp "${{ inputs.templates_folder }}/ingress-template.yaml" ingress-temp.yaml
+
         sed -i "s|{{PR_SUBDOMAIN}}|${{ inputs.pr_number }}-${{ steps.repo-name.outputs.repo_name }}.kpk.dev|g" ingress-temp.yaml
         sed -i "s|{{PR_NUMBER}}|${{ inputs.pr_number }}|g" ingress-temp.yaml
         sed -i "s|{{REPO_NAME}}|${{ steps.repo-name.outputs.repo_name }}|g" ingress-temp.yaml
         sed -i "s|{{PORT}}|${{ inputs.port }}|g" ingress-temp.yaml
-        
-        # Optional: display the modified file for debugging
+
         cat ingress-temp.yaml
       shell: bash
 
     - name: Deploy to Kubernetes
       run: |
+        NAMESPACE="pr-review-${{ steps.repo-name.outputs.repo_name }}"
         kubectl apply -f deployment-temp.yaml -f ingress-temp.yaml
+        echo "namespace=${NAMESPACE}" >> $GITHUB_ENV
       shell: bash
 
-    - name: Clean up
+    - name: Verify deployment rollout
+      id: verify
       run: |
-        rm deployment-temp.yaml
-        rm ingress-temp.yaml
+        DEPLOY_NAME="${{ steps.repo-name.outputs.repo_name }}-${{ inputs.pr_number }}"
+        if kubectl rollout status "deployment/${DEPLOY_NAME}" -n "${namespace}" --timeout=${{ inputs.rollout_timeout }} 2>/dev/null; then
+          echo "status=success" >> $GITHUB_OUTPUT
+          echo "✅ Deployment ${DEPLOY_NAME} rolled out successfully"
+        else
+          echo "status=failure" >> $GITHUB_OUTPUT
+          echo "⚠️ Deployment ${DEPLOY_NAME} did not become ready within ${{ inputs.rollout_timeout }}"
+          kubectl describe "deployment/${DEPLOY_NAME}" -n "${namespace}" 2>/dev/null | tail -20
+        fi
+      shell: bash
+
+    - name: Clean up temp files
+      if: always()
+      run: rm -f deployment-temp.yaml ingress-temp.yaml
       shell: bash


### PR DESCRIPTION
## Summary

- **Replace manual `kubectl` download** with [`azure/setup-kubectl@v4`](https://github.com/azure/setup-kubectl) — faster (cached), version-managed, and avoids the fragile `curl | chmod | mv` pattern
- **Add rollout status verification** after `kubectl apply` with a configurable `rollout_timeout` input (default `120s`) — surfaces deployment failures immediately instead of silently proceeding
- **Export `deployment_url` and `deployment_status`** as action outputs so callers can use them in subsequent steps (e.g. posting deployment status to PR comments)
- **Add `--ignore-not-found`** to cleanup deletes to prevent job failures when resources were only partially created
- **Use `if: always()`** on temp file cleanup to avoid leaving artifacts on failure

## Motivation

The current preview-deployment action applies resources to the cluster but has no way of knowing whether the deployment actually became healthy. If the pod crashes or the image pull fails, the action still reports success and posts the preview URL — leading to confusion when the link returns 502/522.

Adding `kubectl rollout status` after apply catches these failures early and makes the deployment status available as an output for downstream reporting.

## Changes

| File | Change |
|------|--------|
| `preview-deployment/action.yml` | Replace curl kubectl install → `azure/setup-kubectl@v4`; add rollout verification step; add outputs; cleanup with `if: always()` |
| `preview-cleanup/action.yml` | Same kubectl modernization; add `--ignore-not-found` for idempotent deletes |

## Test plan

- [ ] Trigger a preview deployment on a repo that uses this action and verify:
  - `kubectl rollout status` runs after apply
  - `deployment_url` and `deployment_status` outputs are populated
  - Failed deployments surface the error in the action log
- [ ] Trigger a preview cleanup on a closed PR and verify no errors on already-deleted resources